### PR TITLE
Add first version of the trace processor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+gem 'aws-sdk-s3'
+gem 'opencensus'
+gem 'opencensus-stackdriver'
+gem 'sinatra'
+
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     aws-eventstream (1.0.1)
     aws-partitions (1.100.0)
     aws-sdk-core (3.24.1)
@@ -16,16 +18,69 @@ GEM
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.3)
+    concurrent-ruby (1.0.5)
+    faraday (0.15.2)
+      multipart-post (>= 1.2, < 3)
+    google-cloud-core (1.2.3)
+      google-cloud-env (~> 1.0)
+    google-cloud-env (1.0.2)
+      faraday (~> 0.11)
+    google-cloud-trace (0.33.2)
+      google-cloud-core (~> 1.2)
+      google-gax (~> 1.3)
+      stackdriver-core (~> 1.3)
+    google-gax (1.3.0)
+      google-protobuf (~> 3.2)
+      googleapis-common-protos (>= 1.3.5, < 2.0)
+      googleauth (~> 0.6.2)
+      grpc (>= 1.7.2, < 2.0)
+      rly (~> 0.2.3)
+    google-protobuf (3.6.1)
+    googleapis-common-protos (1.3.7)
+      google-protobuf (~> 3.0)
+      googleapis-common-protos-types (~> 1.0)
+      grpc (~> 1.0)
+    googleapis-common-protos-types (1.0.2)
+      google-protobuf (~> 3.0)
+    googleauth (0.6.5)
+      faraday (~> 0.12)
+      jwt (>= 1.4, < 3.0)
+      memoist (~> 0.12)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (~> 0.7)
+    grpc (1.14.1)
+      google-protobuf (~> 3.1)
+      googleapis-common-protos-types (~> 1.0.0)
     jmespath (1.4.0)
+    jwt (2.1.0)
+    memoist (0.16.0)
+    multi_json (1.13.1)
+    multipart-post (2.0.0)
     mustermann (1.0.3)
+    opencensus (0.3.1)
+    opencensus-stackdriver (0.1.2)
+      concurrent-ruby (~> 1.0)
+      google-cloud-trace (~> 0.31)
+      opencensus (~> 0.3)
+    os (1.0.0)
+    public_suffix (3.0.3)
     rack (2.0.5)
     rack-protection (2.0.3)
       rack
+    rly (0.2.3)
+    signet (0.9.0)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
     sinatra (2.0.3)
       mustermann (~> 1.0)
       rack (~> 2.0)
       rack-protection (= 2.0.3)
       tilt (~> 2.0)
+    stackdriver-core (1.3.0)
+      google-cloud-core (~> 1.2)
     tilt (2.0.8)
 
 PLATFORMS
@@ -33,6 +88,8 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk-s3
+  opencensus
+  opencensus-stackdriver
   sinatra
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,39 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    aws-eventstream (1.0.1)
+    aws-partitions (1.100.0)
+    aws-sdk-core (3.24.1)
+      aws-eventstream (~> 1.0)
+      aws-partitions (~> 1.0)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.7.0)
+      aws-sdk-core (~> 3)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-s3 (1.17.0)
+      aws-sdk-core (~> 3, >= 3.21.2)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.0)
+    aws-sigv4 (1.0.3)
+    jmespath (1.4.0)
+    mustermann (1.0.3)
+    rack (2.0.5)
+    rack-protection (2.0.3)
+      rack
+    sinatra (2.0.3)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.3)
+      tilt (~> 2.0)
+    tilt (2.0.8)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  aws-sdk-s3
+  sinatra
+
+BUNDLED WITH
+   1.16.1

--- a/server.rb
+++ b/server.rb
@@ -16,12 +16,12 @@ def s3
     @s3 ||= Aws::S3::Client.new
 end
 
-def process_span(job_id, span_context, trace_json)
-    span = span_context.start_span trace_json['name'], skip_frames: 2
-    span.put_attribute "app", "build"
-    span.put_attribute "job_id", job_id
-    span.start_time = Time.parse(trace_json['start_time'])
-    span.end_time = Time.parse(trace_json['end_time'])
+def process_span(job_id, trace_id, trace_json)
+    builder = OpenCensus::Trace::SpanBuilder::PieceBuilder.new 
+    span_name = builder.truncatable_string(trace_json['name'])
+    status = builder.convert_status(trace_json['status'], "")
+    attributes = builder.convert_attributes({"app"=>"build_test", "job_id"=>job_id})
+    return OpenCensus::Trace::Span.new trace_id, trace_json['id'], span_name, Time.at(trace_json['start_time'].to_i*1e-9), Time.at(trace_json['end_time'].to_i*1e-9), parent_span_id: trace_json['parent_id'], attributes: attributes, status: status
 end
 
 def s3_trace(job_id)
@@ -56,14 +56,9 @@ post '/trace' do
     max_trace_id = OpenCensus::Trace::SpanContext::MAX_TRACE_ID
     trace_id = rand 1..max_trace_id
     trace_id = trace_id.to_s(16).rjust(32, "0")
-    context = OpenCensus::Trace::TraceContextData.new(trace_id, '', 0x01)
-
-    OpenCensus::Trace.start_request_trace \
-    trace_context: context,
-    same_process_as_parent: false do |span_context|
-        tracefile.each_line do |line|
-            process_span(job_id, span_context, JSON.parse(line))
-        end
-        OpenCensus::Trace.config.exporter.export(span_context.build_contained_spans)
+    spans = []
+    tracefile.each_line do |line|
+        spans << process_span(job_id, trace_id, JSON.parse(line))
     end
+    OpenCensus::Trace.config.exporter.export spans
 end

--- a/server.rb
+++ b/server.rb
@@ -16,19 +16,12 @@ def s3
     @s3 ||= Aws::S3::Client.new
 end
 
-def process_trace(job_id, span_context, trace_json)
-    begin
-        span_context.in_span trace_json['name'] do |span|
-            span.kind = ::OpenCensus::Trace::SpanBuilder::SERVER
-            span.put_attribute "app", "build"
-            span.put_attribute "job_id", job_id
-            span.start_time = Time.parse(trace_json['start_time'])
-            span.end_time = Time.parse(trace_json['end_time'])
-        end
-    rescue  => error
-        # This is needed because the block above raises "Span already finished"
-        raise error if error.message != "Span already finished"
-    end
+def process_span(job_id, span_context, trace_json)
+    span = span_context.start_span trace_json['name'], skip_frames: 2
+    span.put_attribute "app", "build"
+    span.put_attribute "job_id", job_id
+    span.start_time = Time.parse(trace_json['start_time'])
+    span.end_time = Time.parse(trace_json['end_time'])
 end
 
 def s3_trace(job_id)
@@ -57,20 +50,20 @@ post '/trace' do
     end
 
     job_id = json_params["job_id"]
-    #tracefile = s3_trace(job_id)
-    tracefile = File.open("trace.json", "r")
+    tracefile = s3_trace(job_id)
 
     # create new trace
     max_trace_id = OpenCensus::Trace::SpanContext::MAX_TRACE_ID
     trace_id = rand 1..max_trace_id
     trace_id = trace_id.to_s(16).rjust(32, "0")
     context = OpenCensus::Trace::TraceContextData.new(trace_id, '', 0x01)
+
     OpenCensus::Trace.start_request_trace \
     trace_context: context,
     same_process_as_parent: false do |span_context|
         tracefile.each_line do |line|
-            process_trace(job_id, span_context, JSON.parse(line))
+            process_span(job_id, span_context, JSON.parse(line))
         end
-        OpenCensus::Trace.config.exporter.export span_context.build_contained_spans
+        OpenCensus::Trace.config.exporter.export(span_context.build_contained_spans)
     end
 end

--- a/server.rb
+++ b/server.rb
@@ -44,12 +44,6 @@ Aws.config.update({
     credentials: Aws::Credentials.new(ENV['S3_ACCESS_KEY_ID'], ENV['S3_SECRET_ACCESS_KEY'])
 })
 
-OpenCensus.configure do |c|
-    c.trace.exporter = OpenCensus::Trace::Exporters::Stackdriver.new
-    c.trace.default_sampler = OpenCensus::Trace::Samplers::AlwaysSample.new
-end
-
-
 # Endpoints:
 
 get '/' do
@@ -57,6 +51,11 @@ get '/' do
 end
 
 post '/trace' do
+    OpenCensus.configure do |c|
+        c.trace.exporter = OpenCensus::Trace::Exporters::Stackdriver.new
+        c.trace.default_sampler = OpenCensus::Trace::Samplers::AlwaysSample.new
+    end
+
     job_id = json_params["job_id"]
     #tracefile = s3_trace(job_id)
     tracefile = File.open("trace.json", "r")

--- a/server.rb
+++ b/server.rb
@@ -1,0 +1,53 @@
+require 'sinatra'
+require 'aws-sdk-s3'
+require 'opencensus'
+require 'opencensus/stackdriver'
+
+
+def json_params
+    begin
+        JSON.parse(request.body.read)
+    rescue
+        halt 400, { message:'Invalid JSON' }.to_json
+    end
+end
+
+def s3
+    @s3 ||= Aws::S3::Client.new
+end
+
+def process_trace(trace_json)
+    puts trace_json
+end
+
+def s3_trace(job_id)
+    obj = s3.get_object(bucket: ENV['S3_BUCKET'], key: "trace/#{job_id}")
+    obj.body.read
+end
+
+
+# Setup
+
+Aws.config.update({
+    region: 'us-east-1',
+    credentials: Aws::Credentials.new(ENV['S3_ACCESS_KEY_ID'], ENV['S3_SECRET_ACCESS_KEY'])
+})
+
+OpenCensus.configure do |c|
+    c.trace.exporter = OpenCensus::Trace::Exporters::Stackdriver.new
+end
+
+
+# Endpoints:
+
+get '/' do
+    'Welcome to the Travis Trace Processor'
+end
+
+post '/trace' do
+    job_id = json_params["job_id"]
+    tracefile = s3_trace(job_id)
+    tracefile.each_line do |line|
+        process_trace(JSON.parse(line))
+    end  
+end


### PR DESCRIPTION
Reference: https://github.com/travis-ci/reliability/issues/153

The build trace processor should fetch trace files from S3 and feed them into Stackdriver Trace.
It expects notifications for each build trace that is saved via a HTTP API.